### PR TITLE
Use endpoint for chat history instead of websocket

### DIFF
--- a/core/chat/client.go
+++ b/core/chat/client.go
@@ -111,6 +111,7 @@ func (c *Client) listenRead() {
 			msg.ID = id
 			msg.MessageType = "CHAT"
 			msg.Timestamp = time.Now()
+			msg.Visible = true
 
 			if err := websocket.JSON.Receive(c.ws, &msg); err == io.EOF {
 				c.doneCh <- true

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -56,12 +56,6 @@ func (s *server) err(err error) {
 	s.errCh <- err
 }
 
-func (s *server) sendPastMessages(c *Client) {
-	for _, msg := range s.Messages {
-		c.Write(msg)
-	}
-}
-
 func (s *server) sendAll(msg models.ChatMessage) {
 	for _, c := range s.Clients {
 		c.Write(msg)
@@ -104,7 +98,6 @@ func (s *server) Listen() {
 			s.Clients[c.id] = c
 
 			s.listener.ClientAdded(c.id)
-			s.sendPastMessages(c)
 
 		// remove a client
 		case c := <-s.delCh:

--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -40,6 +40,7 @@ class Owncast {
 
   init() {
     this.messagingInterface = new MessagingInterface();
+    this.messagingInterface.setChatHistory = this.setChatHistory.bind(this);
     this.websocket = this.setupWebsocket();
 
     this.vueApp = new Vue({
@@ -132,16 +133,24 @@ class Owncast {
         return; 
       }
       const message = new Message(model);
-      const existing = this.vueApp.messages.filter(function (item) {
-        return item.id === message.id;
-      })
-      if (existing.length === 0 || !existing) {
-        this.vueApp.messages = [...this.vueApp.messages, message];
-      }
+      this.addMessage(message);
     };
     this.websocket = ws;
     this.messagingInterface.setWebsocket(this.websocket);
   };
+
+  addMessage(message) {
+    const existing = this.vueApp.messages.filter(function (item) {
+      return item.id === message.id;
+    })
+    if (existing.length === 0 || !existing) {
+      this.vueApp.messages = [...this.vueApp.messages, message];
+    }
+  }
+
+  setChatHistory(messages) {
+    this.vueApp.messages = messages
+  }
 
   // fetch /config data
   getConfig() {

--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -40,7 +40,6 @@ class Owncast {
 
   init() {
     this.messagingInterface = new MessagingInterface();
-    this.messagingInterface.setChatHistory = this.setChatHistory.bind(this);
     this.websocket = this.setupWebsocket();
 
     this.vueApp = new Vue({
@@ -87,6 +86,8 @@ class Owncast {
       onError: this.handlePlayerError,
     });
     this.player.init();
+
+    this.getChatHistory();
   };
 
   setConfigData(data) {
@@ -146,10 +147,6 @@ class Owncast {
     if (existing.length === 0 || !existing) {
       this.vueApp.messages = [...this.vueApp.messages, message];
     }
-  }
-
-  setChatHistory(messages) {
-    this.vueApp.messages = messages
   }
 
   // fetch /config data
@@ -285,4 +282,18 @@ class Owncast {
     this.handleOfflineMode();
     // stop timers?
   };
+
+  async getChatHistory() {
+    const url = "/chat";
+    const response = await fetch(url);
+    const data = await response.json();
+    const messages = data.map(function (message) {
+      return new Message(message);
+    })
+    this.setChatHistory(messages);
+  }
+
+  setChatHistory(messages) {
+    this.vueApp.messages = messages;
+  }
 };

--- a/webroot/js/message.js
+++ b/webroot/js/message.js
@@ -246,12 +246,14 @@ class MessagingInterface {
 	disableChat() {
 		if (this.formMessageInput) {
 			this.formMessageInput.disabled = true;
+			this.formMessageInput.placeholder = "Chat is offline."
 		}
 		// also show "disabled" text/message somewhere.
 	}
 	enableChat() {
 		if (this.formMessageInput) {
 			this.formMessageInput.disabled = false;
+			this.formMessageInput.placeholder = "Message"
 		}
 	}
 	// handle Vue.js message display

--- a/webroot/js/message.js
+++ b/webroot/js/message.js
@@ -96,7 +96,6 @@ class MessagingInterface {
 
 		this.chatDisplayed = getLocalStorage(KEY_CHAT_DISPLAYED) || false;
 		this.displayChat();
-		this.getChatHistory();
 	}
 
 	updateUsernameFields(username) {
@@ -264,15 +263,5 @@ class MessagingInterface {
 			// jump to bottom
 			jumpToBottom(this.scrollableMessagesContainer);
 		}
-	}
-
-	async getChatHistory() {
-		const url = "/chat";
-		const response = await fetch(url);
-		const data = await response.json();
-		const messages = data.map(function (message) {
-			return new Message(message)
-		})
-		this.setChatHistory(messages);
 	}
 }

--- a/webroot/js/message.js
+++ b/webroot/js/message.js
@@ -81,6 +81,7 @@ class MessagingInterface {
 		} else {
 			this.tagAppContainer.classList.add('desktop');
 		}
+
 	}
 
 	setWebsocket(socket) {
@@ -95,6 +96,7 @@ class MessagingInterface {
 
 		this.chatDisplayed = getLocalStorage(KEY_CHAT_DISPLAYED) || false;
 		this.displayChat();
+		this.getChatHistory();
 	}
 
 	updateUsernameFields(username) {
@@ -262,5 +264,15 @@ class MessagingInterface {
 			// jump to bottom
 			jumpToBottom(this.scrollableMessagesContainer);
 		}
+	}
+
+	async getChatHistory() {
+		const url = "/chat";
+		const response = await fetch(url);
+		const data = await response.json();
+		const messages = data.map(function (message) {
+			return new Message(message)
+		})
+		this.setChatHistory(messages);
 	}
 }

--- a/webroot/js/utils.js
+++ b/webroot/js/utils.js
@@ -32,6 +32,9 @@ const VIDEO_SRC = {
 const VIDEO_OPTIONS = {
   autoplay: false,
   liveui: true, // try this
+  liveTracker: {
+    trackingThreshold: 0,
+  },
   sources: [VIDEO_SRC],
 };
 


### PR DESCRIPTION
This uses the `/chat` endpoint for bulk fetching of past chat messages instead of getting one message at a time of the history over the websocket.