### PR TITLE
Set Content-Type on status endpoint

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -13,6 +13,7 @@ func GetStatus(w http.ResponseWriter, r *http.Request) {
 	middleware.EnableCors(&w)
 
 	status := core.GetStatus()
+	w.Header().Set("Content-Type", "application/json")
 
 	json.NewEncoder(w).Encode(status)
 }


### PR DESCRIPTION
Just noticed this was serving as `text/plain`