### PR TITLE
Add ACL option to s3 config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,7 @@ type s3 struct {
 	Secret    string `yaml:"secret"`
 	Bucket    string `yaml:"bucket"`
 	Region    string `yaml:"region"`
+	ACL       string `yaml:"acl"`
 }
 
 func (c *config) load(filePath string) error {


### PR DESCRIPTION
Using DO's Spaces, it appears that one must set the canned ACL explicitly when uploading, or [it will always get set as private](https://www.digitalocean.com/community/questions/spaces-default-permissions) and be inaccessible via HTTP.

This adds a new config option, which can be used like:

```yaml
# Read https://github.com/gabek/owncast/blob/master/doc/S3.md for S3 config details.
s3:
  enabled: false
  endpoint: https://sfo2.digitaloceanspaces.com
  accessKey: ABC12342069
  secret: lolomgqwtf49583949
  region: us-west-2
  bucket: myvideo
  acl: public-read
```

I'm not sure if this is useful beyond my use case; but I can document this in `s3.md` it and put it in the example config if you think it'd be more useful generally.