### PR TITLE
Add username tab completion

### DIFF
--- a/webroot/js/message.js
+++ b/webroot/js/message.js
@@ -23,10 +23,10 @@ class Message {
 			emoji: true, 
 			openLinksInNewWindow: true, 
 			tables: false, 
-			strikethrough: false, 
 			simplifiedAutoLink: false,
 			literalMidWordUnderscores: true,
 			strikethrough: true,
+			ghMentions: false,
 		}).makeHtml(this.body);
 		const linked = autoLink(markdownToHTML, {
 			embed: true,

--- a/webroot/js/message.js
+++ b/webroot/js/message.js
@@ -35,10 +35,17 @@ class Message {
 				target: '_blank'
 			}
 		});
-		return addNewlines(linked);
+		const highlighted = this.highlightUsername(linked);
+		return addNewlines(highlighted);
 	}
 	userColor() {
 		return messageBubbleColorForString(this.author);
+	}
+
+	highlightUsername(message) {
+		const username = document.getElementById('self-message-author').value;
+		const pattern = new RegExp('@?' + username.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'gi');
+		return message.replace(pattern, '<span class="highlighted">$&</span>');
 	}
 }
 

--- a/webroot/styles/layout.css
+++ b/webroot/styles/layout.css
@@ -624,6 +624,11 @@ h2 {
   border-radius: 15px;
 }
 
+.message-text .highlighted {
+  color: orange;
+  font-weight: bold;
+}
+
 .message-text code {
   background-color:darkslategrey;
   padding: 3px;


### PR DESCRIPTION
This pull request adds tab completion on `@` character. It cycles through the list of matching usernames, Twitch style (or so I believe, it's been a while since I last used Twitch).
The list of usernames is taken from the current message history. That should be good enough for most purposes, I think.

I'm opening this as a draft to collect feedback. I'm not sure if there isn't a better way to pass the list of messages, for example.