### PR TITLE
Stop storing messages in memory and pull from db instead. Closes #81

### DIFF
--- a/core/chat/chat.go
+++ b/core/chat/chat.go
@@ -11,7 +11,6 @@ import (
 func Setup(listener models.ChatListener) {
 	setupPersistence()
 
-	messages := []models.ChatMessage{}
 	clients := make(map[string]*Client)
 	addCh := make(chan *Client)
 	delCh := make(chan *Client)
@@ -19,10 +18,8 @@ func Setup(listener models.ChatListener) {
 	pingCh := make(chan models.PingMessage)
 	doneCh := make(chan bool)
 	errCh := make(chan error)
-	messages = append(messages, getChatHistory()...)
 
 	_server = &server{
-		messages,
 		clients,
 		"/entry", //hardcoded due to the UI requiring this and it is not configurable
 		listener,
@@ -71,21 +68,5 @@ func GetMessages() []models.ChatMessage {
 		return []models.ChatMessage{}
 	}
 
-	return getRecentMessages()
-}
-
-func getRecentMessages() []models.ChatMessage {
-	if len(_server.Messages) < 100 {
-		return _server.Messages
-	}
-
-	maxAgeInHours := float64(2)
-	messages := make([]models.ChatMessage, 0)
-	for _, message := range _server.Messages {
-		if time.Since(message.Timestamp).Hours() < maxAgeInHours {
-			messages = append(messages, message)
-		}
-	}
-
-	return messages
+	return getChatHistory()
 }

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -18,8 +18,7 @@ var (
 
 //Server represents the server which handles the chat
 type server struct {
-	Messages []models.ChatMessage
-	Clients  map[string]*Client
+	Clients map[string]*Client
 
 	pattern  string
 	listener models.ChatListener
@@ -113,7 +112,6 @@ func (s *server) Listen() {
 
 		// broadcast a message to all clients
 		case msg := <-s.sendAllCh:
-			s.Messages = append(s.Messages, msg)
 			s.listener.MessageSent(msg)
 			s.sendAll(msg)
 			addMessage(msg)


### PR DESCRIPTION
We're not using the in-memory messages for anything but the `/chat` API, and they're not being filtered, so just use the DB query instead.