### PR TITLE
Transcoder updates for bitrate validator warnings 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -197,6 +197,15 @@ func (c *config) GetVideoStreamQualities() []StreamQuality {
 	return _default.VideoSettings.StreamQualities
 }
 
+// GetFramerate returns the framerate or default
+func (q *StreamQuality) GetFramerate() int {
+	if q.Framerate > 0 {
+		return q.Framerate
+	}
+
+	return _default.VideoSettings.StreamQualities[0].Framerate
+}
+
 //Load tries to load the configuration file
 func Load(filePath string, versionInfo string) error {
 	Config = new(config)

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -21,6 +21,7 @@ func getDefaults() config {
 		IsAudioPassthrough: true,
 		VideoBitrate:       1200,
 		EncoderPreset:      "veryfast",
+		Framerate:          24,
 	}
 	defaults.VideoSettings.StreamQualities = []StreamQuality{defaultQuality}
 

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -282,7 +282,7 @@ func (v *HLSVariant) getVideoQualityString(t *Transcoder) string {
 	// Adjust the max & buffer size until the output bitrate doesn't exceed the ~+10% that Apple's media validator
 	// complains about.
 	maxBitrate := int(float64(v.videoBitrate) * 1.07) // Max is a ~+10% over specified bitrate.
-	bufferSize := int(float64(maxBitrate) * 1.2)      // How often it checks the bitrate of encoded segments to see if it's too high/low.
+	bufferSize := int(float64(v.videoBitrate) * 1.4)  // How often it checks the bitrate of encoded segments to see if it's too high/low.
 
 	cmd := []string{
 		"-map v:0",

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -205,9 +205,9 @@ func NewTranscoder() Transcoder {
 }
 
 // Uses `map` https://www.ffmpeg.org/ffmpeg-all.html#Stream-specifiers-1 https://www.ffmpeg.org/ffmpeg-all.html#Advanced-options
-func (v *HLSVariant) getVariantString() string {
+func (v *HLSVariant) getVariantString(t *Transcoder) string {
 	variantEncoderCommands := []string{
-		v.getVideoQualityString(),
+		v.getVideoQualityString(t),
 		v.getAudioQualityString(),
 	}
 
@@ -230,7 +230,7 @@ func (t *Transcoder) getVariantsString() string {
 	var variantsStreamMaps = " -var_stream_map \""
 
 	for _, variant := range t.variants {
-		variantsCommandFlags = variantsCommandFlags + " " + variant.getVariantString()
+		variantsCommandFlags = variantsCommandFlags + " " + variant.getVariantString(t)
 		variantsStreamMaps = variantsStreamMaps + fmt.Sprintf("v:%d,a:%d ", variant.index, variant.index)
 	}
 	variantsCommandFlags = variantsCommandFlags + " " + variantsStreamMaps + "\""
@@ -265,7 +265,7 @@ func (v *HLSVariant) SetVideoBitrate(bitrate int) {
 	v.videoBitrate = bitrate
 }
 
-func (v *HLSVariant) getVideoQualityString() string {
+func (v *HLSVariant) getVideoQualityString(t *Transcoder) string {
 	if v.isVideoPassthrough {
 		return fmt.Sprintf("-map v:0 -c:v:%d copy", v.index)
 	}
@@ -274,7 +274,7 @@ func (v *HLSVariant) getVideoQualityString() string {
 
 	// -1 to work around segments being generated slightly larger than expected.
 	// https://trac.ffmpeg.org/ticket/6915?replyto=58#comment:57
-	gop := (config.Config.GetVideoSegmentSecondsLength() * v.framerate) - 1
+	gop := (t.segmentLengthSeconds * v.framerate) - 1
 
 	// For limiting the output bitrate
 	// https://trac.ffmpeg.org/wiki/Limiting%20the%20output%20bitrate

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -281,8 +281,8 @@ func (v *HLSVariant) getVideoQualityString(t *Transcoder) string {
 	// https://developer.apple.com/documentation/http_live_streaming/about_apple_s_http_live_streaming_tools
 	// Adjust the max & buffer size until the output bitrate doesn't exceed the ~+10% that Apple's media validator
 	// complains about.
-	maxBitrate := int(float64(v.videoBitrate) * 1.07) // Max is a ~+10% over specified bitrate.
-	bufferSize := int(float64(v.videoBitrate) * 1.4)  // How often it checks the bitrate of encoded segments to see if it's too high/low.
+	maxBitrate := int(float64(v.videoBitrate) * 1.06) // Max is a ~+10% over specified bitrate.
+	bufferSize := int(float64(v.videoBitrate) * 1.2)  // How often it checks the bitrate of encoded segments to see if it's too high/low.
 
 	cmd := []string{
 		"-map v:0",

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -282,7 +282,7 @@ func (v *HLSVariant) getVideoQualityString(t *Transcoder) string {
 	// Adjust the max & buffer size until the output bitrate doesn't exceed the ~+10% that Apple's media validator
 	// complains about.
 	maxBitrate := int(float64(v.videoBitrate) * 1.07) // Max is a ~+10% over specified bitrate.
-	bufferSize := int(float64(maxBitrate) * 1.5)      // How often it checks the bitrate of encoded segments to see if it's too high/low.
+	bufferSize := int(float64(maxBitrate) * 1.2)      // How often it checks the bitrate of encoded segments to see if it's too high/low.
 
 	cmd := []string{
 		"-map v:0",

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -283,7 +283,18 @@ func (v *HLSVariant) getVideoQualityString() string {
 	// complains about.
 	maxBitrate := int(float64(v.videoBitrate) * 1.07) // Max is a ~+10% over specified bitrate.
 	bufferSize := int(float64(maxBitrate) * 1.5)      // How often it checks the bitrate of encoded segments to see if it's too high/low.
-	return fmt.Sprintf("-map v:0 -c:v:%d %s -b:v:%d %dk -maxrate:v:%d %dk -bufsize:v:%d %dk -g:v:%d %d -x264-params:v:%d \"scenecut=0:open_gop=0:min-keyint=%d:keyint=%d\"", v.index, encoderCodec, v.index, v.videoBitrate, v.index, maxBitrate, v.index, bufferSize, v.index, gop, v.index, gop, gop)
+
+	cmd := []string{
+		"-map v:0",
+		fmt.Sprintf("-c:v:%d %s", v.index, encoderCodec),                                                      // Video codec used for this variant
+		fmt.Sprintf("-b:v:%d %dk", v.index, v.videoBitrate),                                                   // The average bitrate for this variant
+		fmt.Sprintf("-maxrate:v:%d %dk", v.index, maxBitrate),                                                 // The max bitrate allowed for this variant
+		fmt.Sprintf("-bufsize:v:%d %dk", v.index, bufferSize),                                                 // How often the encoder checks the bitrate in order to meet average/max values
+		fmt.Sprintf("-g:v:%d %d", v.index, gop),                                                               // How often i-frames are encoded into the segments
+		fmt.Sprintf("-x264-params:v:%d \"scenecut=0:open_gop=0:min-keyint=%d:keyint=%d\"", v.index, gop, gop), // How often i-frames are encoded into the segments
+	}
+
+	return strings.Join(cmd, " ")
 }
 
 // SetVideoFramerate will set the output framerate of this variant's video

--- a/core/ffmpeg/transcoder_test.go
+++ b/core/ffmpeg/transcoder_test.go
@@ -22,7 +22,7 @@ func TestFFmpegCommand(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := `cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1284k -bufsize:v:0 1926k -g:v:0 119 -x264-params:v:0 "scenecut=0:open_gop=0:min-keyint=119:keyint=119" -map a:0 -c:a:0 copy -r 30 -preset veryfast  -var_stream_map "v:0,a:0 " -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log`
+	expected := `cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1284k -bufsize:v:0 1540k -g:v:0 119 -x264-params:v:0 "scenecut=0:open_gop=0:min-keyint=119:keyint=119" -map a:0 -c:a:0 copy -r 30 -preset veryfast  -var_stream_map "v:0,a:0 " -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.  Got %s, want: %s", cmd, expected)

--- a/core/ffmpeg/transcoder_test.go
+++ b/core/ffmpeg/transcoder_test.go
@@ -22,7 +22,7 @@ func TestFFmpegCommand(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := `cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1284k -bufsize:v:0 1680k -g:v:0 119 -x264-params:v:0 "scenecut=0:open_gop=0:min-keyint=119:keyint=119" -map a:0 -c:a:0 copy -r 30 -preset veryfast  -var_stream_map "v:0,a:0 " -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log`
+	expected := `cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1272k -bufsize:v:0 1440k -g:v:0 119 -x264-params:v:0 "scenecut=0:open_gop=0:min-keyint=119:keyint=119" -map a:0 -c:a:0 copy -r 30 -preset veryfast  -var_stream_map "v:0,a:0 " -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.  Got %s, want: %s", cmd, expected)

--- a/core/ffmpeg/transcoder_test.go
+++ b/core/ffmpeg/transcoder_test.go
@@ -22,7 +22,7 @@ func TestFFmpegCommand(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := `cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1284k -bufsize:v:0 1540k -g:v:0 119 -x264-params:v:0 "scenecut=0:open_gop=0:min-keyint=119:keyint=119" -map a:0 -c:a:0 copy -r 30 -preset veryfast  -var_stream_map "v:0,a:0 " -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log`
+	expected := `cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1284k -bufsize:v:0 1680k -g:v:0 119 -x264-params:v:0 "scenecut=0:open_gop=0:min-keyint=119:keyint=119" -map a:0 -c:a:0 copy -r 30 -preset veryfast  -var_stream_map "v:0,a:0 " -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.  Got %s, want: %s", cmd, expected)

--- a/core/ffmpeg/transcoder_test.go
+++ b/core/ffmpeg/transcoder_test.go
@@ -13,7 +13,7 @@ func TestFFmpegCommand(t *testing.T) {
 	transcoder.SetHLSPlaylistLength(10)
 
 	variant := HLSVariant{}
-	variant.videoBitrate = "1200k"
+	variant.videoBitrate = 1200
 	variant.isAudioPassthrough = true
 	variant.encoderPreset = "veryfast"
 	variant.SetVideoFramerate(30)
@@ -22,7 +22,7 @@ func TestFFmpegCommand(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := "cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -map a:0 -c:a:0 copy -r 30 -g 60 -keyint_min 60 -preset veryfast  -var_stream_map \"v:0,a:0 \" -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log"
+	expected := `cat fakecontent.flv | /fake/path/ffmpeg -hide_banner -i pipe:  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1284k -bufsize:v:0 1926k -g:v:0 119 -x264-params:v:0 "scenecut=0:open_gop=0:min-keyint=119:keyint=119" -map a:0 -c:a:0 copy -r 30 -preset veryfast  -var_stream_map "v:0,a:0 " -f hls -hls_time 4 -hls_list_size 10 -hls_delete_threshold 10 -hls_flags delete_segments+program_date_time+temp_file -tune zerolatency -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename fakeOutput/%v/stream-%s.ts -max_muxing_queue_size 400 fakeOutput/%v/stream.m3u8 2> transcoder.log`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.  Got %s, want: %s", cmd, expected)


### PR DESCRIPTION
This change aims to fix the HLS validator warnings that arise due to spikes in bitrate and hopefully resolve the issue that #50 sees where it's dropping to the lower quality bitrate even when the higher one is perfectly fine.