### PR TITLE
Remove cache-control header from HLS queries

### DIFF
--- a/webroot/js/player.js
+++ b/webroot/js/player.js
@@ -48,10 +48,7 @@ class OwncastPlayer {
   init() {
     videojs.Hls.xhr.beforeRequest = function (options) {
       const cachebuster = Math.round(new Date().getTime() / 1000);
-      options.uri = options.uri + "?omgwtf=" + cachebuster;
-      options.headers = {
-        'Cache-Control':'no-cache'
-      };
+      options.uri = `${options.uri}?cachebust=${cachebuster}`;
       return options;
     };
 


### PR DESCRIPTION
Also minor refactor around cachebusting. I considered changing the key to `omgwtfbbq` but thought better of it 🙃 

Fixes #117 